### PR TITLE
:sparkles: feat: auth module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,11 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.logback.classic)
     implementation(libs.ktor.server.config.yaml)
+    implementation("io.ktor:ktor-client-content-negotiation-jvm:3.1.0")
+    implementation("io.github.cdimascio:dotenv-kotlin:6.5.0")
+    implementation("io.ktor:ktor-client-core:3.1.0")
+    implementation("io.ktor:ktor-client-cio:3.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlin.test.junit)
 }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -1,19 +1,9 @@
 package com.pace42.student
 
-import com.pace42.student.plugins.configureHTTP
-import com.pace42.student.routes.configureRouting
-import com.pace42.student.plugins.configureSecurity
-import com.pace42.student.plugins.configureSerialization
-import io.ktor.server.application.*
-import io.ktor.server.netty.*
+import com.pace42.student.auth.fetch42token
 
-fun main(args: Array<String>) {
-    EngineMain.main(args)
+suspend fun main() {
+    val token42 = fetch42token()
+    println(token42)
 }
 
-fun Application.module() {
-    configureSecurity()
-    configureSerialization()
-    configureHTTP()
-    configureRouting()
-}

--- a/src/main/kotlin/com/pace42/student/auth/Authentication.kt
+++ b/src/main/kotlin/com/pace42/student/auth/Authentication.kt
@@ -1,0 +1,58 @@
+package com.pace42.student.auth
+
+import io.github.cdimascio.dotenv.dotenv
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.utils.io.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class Token(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_in") val expiresIn: Int,
+    @SerialName("scope") val scope: String,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("secret_valid_until") val secretValidUntil: Long
+)
+
+@OptIn(InternalAPI::class)
+suspend fun fetch42token(): String {
+
+    val dotenv = dotenv()
+    val userId42 = dotenv["UID_42"]
+    val secret42 = dotenv["SECRET_42"]
+
+    val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true  // In case the API sends fields you don't need
+                coerceInputValues = true  // Helps with nullable fields
+            })
+        }
+    }
+
+    try {
+        val response: HttpResponse = client.post("https://api.intra.42.fr/oauth/token"){
+            body = FormDataContent(Parameters.build {
+                append("grant_type", "client_credentials")
+                append("client_id", userId42)
+                append("client_secret", secret42)
+            })
+        }
+        val token: Token = Json.decodeFromString(response.bodyAsText())
+        return token.accessToken
+
+    } catch (e: Exception) {
+        println(" 42Error fetching token: ${e.message}")
+        throw e
+    }
+}


### PR DESCRIPTION
Add the Authentication module, that fetches `access_token` from 42 API.

-  It uses `dotenv` to pass the required `UID` and `SECRET` and POST the proper endpoint (`https://api.intra.42.fr/oauth/token`).
- Use serialization to parse the token itself. The rest of the fields are ignored for now.