### PR TITLE
:sparkles: feat: export module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.csv
 .env
 .gradle
 build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation("io.ktor:ktor-client-core:3.1.0")
     implementation("io.ktor:ktor-client-cio:3.1.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    implementation("org.apache.commons:commons-csv:1.13.0")
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlin.test.junit)
 }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -21,7 +21,7 @@ suspend fun main() {
 
         // Export to CSV
         val outputPath = Path("students_export.csv")
-        StudentCSVExporter.exportToCSV(students, outputPath)
+        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
         println("CSV exported successfully to: ${outputPath.absolutePathString()}")
 
     } catch (e: Exception) {

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -1,7 +1,10 @@
 package com.pace42.student
 
 import com.pace42.student.auth.fetch42token
+import com.pace42.student.export.StudentCSVExporter
 import com.pace42.student.student.StudentAPI
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
 
 suspend fun main() {
     val token42 = try {
@@ -15,11 +18,11 @@ suspend fun main() {
         val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
         studentAPI.close()
         println("Number of students: ${students.size}")
-        if (students.isNotEmpty()) {
-            println("First student: ${students.first()}")
-        } else {
-            println("No students found")
-        }
+
+        // Export to CSV
+        val outputPath = Path("students_export.csv")
+        StudentCSVExporter.exportToCSV(students, outputPath)
+        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
 
     } catch (e: Exception) {
         return

--- a/src/main/kotlin/com/pace42/student/export/Export.kt
+++ b/src/main/kotlin/com/pace42/student/export/Export.kt
@@ -9,38 +9,50 @@ import kotlin.io.path.absolutePathString
 
 class StudentCSVExporter {
     companion object {
-        private val HEADERS = arrayOf(
-            "ID",
+        // Headers for different export types
+        private val STUDENT_BASIC_HEADERS = arrayOf(
+            "Cohort",
             "Login",
             "First Name",
             "Last Name",
             "Email",
-            "Profile URL",
             "Pool Month",
             "Pool Year",
-            "Cohort"
+            "Profile URL",
+            "Graph URL"
         )
 
-        fun exportToCSV(students: List<Student>, outputPath: Path) {
+        fun exportBasicStudentInfo(students: List<Student>, outputPath: Path) {
+            exportToCSV(students, outputPath, STUDENT_BASIC_HEADERS) { student ->
+                arrayOf(
+                    student.cohort,
+                    student.login,
+                    student.firstName,
+                    student.lastName,
+                    student.email,
+                    student.poolMonth,
+                    student.poolYear,
+                    student.profileUrl,
+                    student.graphUrl
+                )
+            }
+        }
+
+        private fun exportToCSV(
+            students: List<Student>,
+            outputPath: Path,
+            headers: Array<String>,
+            recordMapper: (Student) -> Array<String>
+        ) {
             FileWriter(outputPath.absolutePathString()).use { writer ->
                 CSVFormat.DEFAULT
                     .builder()
-                    .setHeader(*HEADERS)
+                    .setHeader(*headers)
                     .build()
                     .print(writer)
                     .use { csvPrinter ->
                         students.forEach { student ->
-                            csvPrinter.printRecord(
-                                student.id,
-                                student.login,
-                                student.firstName,
-                                student.lastName,
-                                student.email,
-                                student.profileUrl,
-                                student.poolMonth,
-                                student.poolYear,
-                                student.cohort
-                            )
+                            csvPrinter.printRecord(*recordMapper(student))
                         }
                     }
             }

--- a/src/main/kotlin/com/pace42/student/export/Export.kt
+++ b/src/main/kotlin/com/pace42/student/export/Export.kt
@@ -1,0 +1,49 @@
+package com.pace42.student.export
+
+import com.pace42.student.student.Student
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+import java.io.FileWriter
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+class StudentCSVExporter {
+    companion object {
+        private val HEADERS = arrayOf(
+            "ID",
+            "Login",
+            "First Name",
+            "Last Name",
+            "Email",
+            "Profile URL",
+            "Pool Month",
+            "Pool Year",
+            "Cohort"
+        )
+
+        fun exportToCSV(students: List<Student>, outputPath: Path) {
+            FileWriter(outputPath.absolutePathString()).use { writer ->
+                CSVFormat.DEFAULT
+                    .builder()
+                    .setHeader(*HEADERS)
+                    .build()
+                    .print(writer)
+                    .use { csvPrinter ->
+                        students.forEach { student ->
+                            csvPrinter.printRecord(
+                                student.id,
+                                student.login,
+                                student.firstName,
+                                student.lastName,
+                                student.email,
+                                student.profileUrl,
+                                student.poolMonth,
+                                student.poolYear,
+                                student.cohort
+                            )
+                        }
+                    }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/pace42/student/student/Student.kt
+++ b/src/main/kotlin/com/pace42/student/student/Student.kt
@@ -11,8 +11,9 @@ data class Student(
     @SerialName("first_name") val firstName: String,
     @SerialName("last_name") val lastName: String,
     val email: String,
-    @SerialName("url") val profileUrl: String,
     @SerialName("pool_month") val poolMonth: String,
     @SerialName("pool_year") val poolYear: String,
+    val profileUrl: String = "https://profile.intra.42.fr/users/",
+    val graphUrl: String = "https://projects.intra.42.fr/projects/graph?login=",
     val cohort: String = "Unknown"
 )

--- a/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
+++ b/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
@@ -92,9 +92,14 @@ class StudentAPI(private val token42: String) {
                 }
             }
 
-            // add cohort tag to every student
+            //https://projects.intra.42.fr/projects/graph?login=pmarkaid
+            // add cohort tag to every student and correct urls
             return allStudents.map { student ->
-                student.copy(cohort = cohort)
+                student.copy(
+                    cohort = cohort,
+                    profileUrl = student.profileUrl + student.login,
+                    graphUrl = student.graphUrl + student.login
+                )
             }
 
         } catch (e: Exception) {

--- a/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
+++ b/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
@@ -92,7 +92,6 @@ class StudentAPI(private val token42: String) {
                 }
             }
 
-            //https://projects.intra.42.fr/projects/graph?login=pmarkaid
             // add cohort tag to every student and correct urls
             return allStudents.map { student ->
                 student.copy(


### PR DESCRIPTION
Add the module to export API data into a .csv file.

### Major
* After fetching a given number of students or cohorts into a `List<Student>`, a CSV file is generated using `apache.commons.csv`—one row per student.
* The order of the fields is hardcoded and, for now, ordered from most important to less important basis.
* The module accepts new functions to export new types of data (like the future Quest summaries or a combination of both)