### PR TITLE
:sparkles: feat: quest module

### DIFF
--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -25,7 +25,7 @@ suspend fun main() {
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchQuestProgress("plang")
+        val quests = questAPI.fetchQuestProgress("aapadill")
         quests.forEach { quest ->
             println(quest)
         }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -25,7 +25,7 @@ suspend fun main() {
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchQuestProgress("aapadill")
+        val quests = questAPI.fetchQuestProgress("upolat")
         quests.forEach { quest ->
             println(quest)
         }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -1,10 +1,6 @@
 package com.pace42.student
 
 import com.pace42.student.auth.fetch42token
-import com.pace42.student.export.StudentCSVExporter
-import com.pace42.student.student.StudentAPI
-import kotlin.io.path.Path
-import kotlin.io.path.absolutePathString
 import com.pace42.student.quest.QuestAPI
 
 suspend fun main() {
@@ -25,7 +21,7 @@ suspend fun main() {
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchQuestList("pmarkaid")
+        val quests = questAPI.fetchUserQuest("pmarkaid")
        quests.forEach(::println)
     } catch (e: Exception) {
         return

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -1,7 +1,11 @@
 package com.pace42.student
 
 import com.pace42.student.auth.fetch42token
+import com.pace42.student.export.StudentCSVExporter
 import com.pace42.student.quest.QuestAPI
+import com.pace42.student.student.StudentAPI
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
 
 suspend fun main() {
     val token42 = try {
@@ -10,19 +14,24 @@ suspend fun main() {
         return
     }
 
-//    val studentAPI = StudentAPI(token42)
+    val studentAPI = StudentAPI(token42)
     val questAPI = QuestAPI(token42)
     try {
 //        val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
 //        studentAPI.close()
 //        println("Number of students: ${students.size}")
-//
+
 //        // Export to CSV
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchUserQuest("pmarkaid")
-       quests.forEach(::println)
+        val quests = questAPI.fetchQuestProgress("pmarkaid")
+        quests.forEach { quest ->
+            println(quest)
+        }
+
+
+
     } catch (e: Exception) {
         return
     }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -3,6 +3,8 @@ package com.pace42.student
 import com.pace42.student.auth.fetch42token
 import com.pace42.student.export.StudentCSVExporter
 import com.pace42.student.quest.QuestAPI
+import com.pace42.student.quest.QuestProgress
+import com.pace42.student.student.Student
 import com.pace42.student.student.StudentAPI
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
@@ -14,8 +16,6 @@ suspend fun main() {
         return
     }
 
-    val studentAPI = StudentAPI(token42)
-    val questAPI = QuestAPI(token42)
     try {
 //        val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
 //        studentAPI.close()
@@ -25,12 +25,19 @@ suspend fun main() {
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchQuestProgress("upolat")
-        quests.forEach { quest ->
-            println(quest)
+//        val quests = questAPI.fetchQuestProgress("upolat")
+//        quests.forEach { quest ->
+//            println(quest)
+//        }
+
+
+        val questAPI = QuestAPI(token42)
+        try {
+            val progress = questAPI.fetchCohortsQuestProgress("Hiver5", "Hiver6", "Hiver7")
+            println("Fetched progress for ${progress.size} quest entries")
+        } finally {
+            questAPI.close()
         }
-
-
 
     } catch (e: Exception) {
         return

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -5,6 +5,7 @@ import com.pace42.student.export.StudentCSVExporter
 import com.pace42.student.student.StudentAPI
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
+import com.pace42.student.quest.QuestAPI
 
 suspend fun main() {
     val token42 = try {
@@ -13,17 +14,19 @@ suspend fun main() {
         return
     }
 
-    val studentAPI = StudentAPI(token42)
+//    val studentAPI = StudentAPI(token42)
+    val questAPI = QuestAPI(token42)
     try {
-        val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
-        studentAPI.close()
-        println("Number of students: ${students.size}")
-
-        // Export to CSV
-        val outputPath = Path("students_export.csv")
-        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
-        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-
+//        val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
+//        studentAPI.close()
+//        println("Number of students: ${students.size}")
+//
+//        // Export to CSV
+//        val outputPath = Path("students_export.csv")
+//        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
+//        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
+        val quests = questAPI.fetchQuestList("pmarkaid")
+       quests.forEach(::println)
     } catch (e: Exception) {
         return
     }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -33,8 +33,8 @@ suspend fun main() {
 
         val questAPI = QuestAPI(token42)
         try {
-            val progress = questAPI.fetchCohortsQuestProgress("Hiver5", "Hiver6", "Hiver7")
-            println("Fetched progress for ${progress.size} quest entries")
+            val quests = questAPI.fetchCampusQuests()
+            println("Fetched quests for ${quests.size} quest entries")
         } finally {
             questAPI.close()
         }

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -25,7 +25,7 @@ suspend fun main() {
 //        val outputPath = Path("students_export.csv")
 //        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
 //        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-        val quests = questAPI.fetchQuestProgress("pmarkaid")
+        val quests = questAPI.fetchQuestProgress("plang")
         quests.forEach { quest ->
             println(quest)
         }

--- a/src/main/kotlin/com/pace42/student/quest/Quest.kt
+++ b/src/main/kotlin/com/pace42/student/quest/Quest.kt
@@ -24,5 +24,5 @@ data class QuestProgress(
     val login: String,
     val rankName: String,
     val validatedDate: String?,
-    val daysBehind: Long?
+    val daysBuffer: Long?
 )

--- a/src/main/kotlin/com/pace42/student/quest/Quest.kt
+++ b/src/main/kotlin/com/pace42/student/quest/Quest.kt
@@ -9,8 +9,8 @@ data class QuestName(
 )
 
 @Serializable
-data class QuestList(
+data class Quest(
     @SerialName("validated_at")
-    val validatedAt: String,
+    val validatedAt: String?,
     val quest: QuestName
 )

--- a/src/main/kotlin/com/pace42/student/quest/Quest.kt
+++ b/src/main/kotlin/com/pace42/student/quest/Quest.kt
@@ -1,7 +1,9 @@
 package com.pace42.student.quest
 
+import com.pace42.student.student.Student
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
 
 @Serializable
 data class QuestName(
@@ -12,5 +14,15 @@ data class QuestName(
 data class Quest(
     @SerialName("validated_at")
     val validatedAt: String?,
-    val quest: QuestName
+    val quest: QuestName,
+    val user: Student
+)
+
+@Serializable
+data class QuestProgress(
+    val cohort: String,
+    val login: String,
+    val rankName: String,
+    val validatedDate: String?,
+    val daysBehind: Long?
 )

--- a/src/main/kotlin/com/pace42/student/quest/Quest.kt
+++ b/src/main/kotlin/com/pace42/student/quest/Quest.kt
@@ -1,0 +1,16 @@
+package com.pace42.student.quest
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestName(
+    val name: String,
+)
+
+@Serializable
+data class QuestList(
+    @SerialName("validated_at")
+    val validatedAt: String,
+    val quest: QuestName
+)

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -1,0 +1,2 @@
+package com.pace42.student.quest
+

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -6,7 +6,6 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
-import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 
 
@@ -34,14 +33,19 @@ class QuestAPI(private val token42: String) {
 //        }.awaitAll().flatten()
 //    }
 
-    suspend fun fetchQuestList(login: String): List<Quest> {
+    suspend fun fetchUserQuest(login: String): List<Quest> {
 
         try {
-             return  client.get("https://api.intra.42.fr/v2/users/${login}/quests_users") {
+             val quests =  client.get("https://api.intra.42.fr/v2/users/${login}/quests_users") {
                      headers {
                         append("Authorization", "Bearer $token42")
                     }
                 }.body<List<Quest>>()
+
+            return quests.map { quest ->
+                quest.copy(
+                    validatedAt = quest.validatedAt?.split("T")?.get(0)
+                ) }
         } catch (e: Exception) {
             println(e)
             return emptyList()

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -7,7 +7,8 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
-
+import com.pace42.student.utils.CohortUtils
+import com.pace42.student.utils.TimeUtils
 
 
 class QuestAPI(private val token42: String) {
@@ -33,7 +34,7 @@ class QuestAPI(private val token42: String) {
 //        }.awaitAll().flatten()
 //    }
 
-    suspend fun fetchUserQuest(login: String): List<Quest> {
+    suspend fun fetchUserQuests(login: String): List<Quest> {
 
         try {
              val quests =  client.get("https://api.intra.42.fr/v2/users/${login}/quests_users") {
@@ -49,6 +50,44 @@ class QuestAPI(private val token42: String) {
         } catch (e: Exception) {
             println(e)
             return emptyList()
+        }
+    }
+
+    suspend fun fetchQuestProgress(login: String): List<QuestProgress> {
+        val quests = fetchUserQuests(login)
+
+        val first = quests.first()
+        val cohort = CohortUtils.getCohortFromYearMonth(first.user.poolYear, first.user.poolMonth)
+
+        val startDate = when(cohort) {
+            "Hiver5" -> "2023-10-23"
+            "Hiver6" -> "2024-04-15"
+            "Hiver7" -> "2024-10-28"
+            else -> "Unknown"
+        }
+        println("cohort: $cohort startDate: $startDate")
+
+        fun getHardDeadline(rank: String): Int? {
+            return when (rank) {
+                "Common Core Rank 00" -> 28
+                "Common Core Rank 01" -> 90
+                "Common Core Rank 02" -> 181
+                "Common Core Rank 03" -> 261
+                "Common Core Rank 04" -> 361
+                "Common Core Rank 05" -> 480
+                "Common Core Rank 06" -> 550
+                else -> null
+            }
+        }
+        return quests.map { quest ->
+            val daysNeededToEvaluate = TimeUtils.daysBetween(startDate, quest.validatedAt)
+            val hardDeadline = getHardDeadline(quest.quest.name)
+            val dayDifference = if (hardDeadline != null && daysNeededToEvaluate != null) {
+                hardDeadline - daysNeededToEvaluate
+            } else {
+                null
+            }
+            QuestProgress(cohort, first.user.login, quest.quest.name, quest.validatedAt, dayDifference)
         }
     }
 }

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -1,2 +1,50 @@
 package com.pace42.student.quest
 
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+
+
+
+class QuestAPI(private val token42: String) {
+
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                prettyPrint = true
+                coerceInputValues = true
+            })
+        }
+    }
+
+    fun close() {
+        client.close()
+    }
+
+//    // Coroutine fetch of all cohorts
+//    suspend fun fetchCohorts(vararg cohorts: String): List<Student> = coroutineScope {
+//        cohorts.map { cohort ->
+//            async { fetchCohort(cohort) }
+//        }.awaitAll().flatten()
+//    }
+
+    suspend fun fetchQuestList(login: String): List<Quest> {
+
+        try {
+             return  client.get("https://api.intra.42.fr/v2/users/${login}/quests_users") {
+                     headers {
+                        append("Authorization", "Bearer $token42")
+                    }
+                }.body<List<Quest>>()
+        } catch (e: Exception) {
+            println(e)
+            return emptyList()
+        }
+    }
+}

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -97,7 +97,7 @@ class QuestAPI(private val token42: String) {
                 // For completed ranks: compare validation date against deadline
                 validatedAt != null -> {
                     val daysToComplete = TimeUtils.daysBetween(startDate, validatedAt) ?: 0
-                    daysToComplete - deadline // Negative means early completion
+                    deadline - daysToComplete // Negative means late completion
                 }
                 // For the first uncompleted rank: compare current days against deadline
                 rankName == firstUncompletedRank -> {
@@ -111,7 +111,7 @@ class QuestAPI(private val token42: String) {
                 login = first.user.login,
                 rankName = rankName,
                 validatedDate = validatedAt,
-                daysBehind = dayDifference
+                daysBuffer = dayDifference
             )
         }
     }

--- a/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
+++ b/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
@@ -106,5 +106,33 @@ class StudentAPI(private val token42: String) {
             return emptyList()
         }
     }
+
+    private fun getCohortFromYearMonth(year: String, month: String): String {
+        return when {
+            year == "2023" && month.lowercase() in listOf("july", "august") -> "Hiver5"
+            year == "2024" && month.lowercase() in listOf("january", "february") -> "Hiver6"
+            year == "2024" && month.lowercase() in listOf("july", "august", "september") -> "Hiver7"
+            else -> "Unknown"
+        }
+    }
+
+    suspend fun fetchStudent(login: String): List<Student> {
+        val response = client.get("https://api.intra.42.fr/v2/users?"){
+            headers {
+                append("Authorization", "Bearer $token42")
+            }
+            parameter("filter[login]", login)
+        }
+
+        return response.body<List<Student>>().map { student ->
+            val cohort = getCohortFromYearMonth(student.poolYear, student.poolMonth)
+            student.copy(
+                cohort = cohort,
+                profileUrl = student.profileUrl + student.login,
+                graphUrl = student.graphUrl + student.login
+            )
+        }
+
+    }
 }
 

--- a/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
+++ b/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
+import com.pace42.student.utils.CohortUtils
 
 
 class StudentAPI(private val token42: String) {
@@ -33,14 +34,6 @@ class StudentAPI(private val token42: String) {
         val month: String,
     )
 
-    private fun getYearMonthFromCohort(cohort: String): CohortDates {
-        return when (cohort) {
-            "Hiver5" -> CohortDates("2023", "july,august")
-            "Hiver6" -> CohortDates("2024", "january,february")
-            "Hiver7" -> CohortDates("2024", "july,august,september")
-            else -> CohortDates("Unknown", "Unknown")
-        }
-    }
 
     // Coroutine fetch of all cohorts
     suspend fun fetchCohorts(vararg cohorts: String): List<Student> = coroutineScope {
@@ -55,7 +48,7 @@ class StudentAPI(private val token42: String) {
         val pageSize = 100
         val allStudents = mutableListOf<Student>()
 
-        val cohortDates = getYearMonthFromCohort(cohort)
+        val cohortDates = CohortUtils.getYearMonthFromCohort(cohort)
         try {
             while (true) {
                 delay(500)
@@ -107,15 +100,6 @@ class StudentAPI(private val token42: String) {
         }
     }
 
-    private fun getCohortFromYearMonth(year: String, month: String): String {
-        return when {
-            year == "2023" && month.lowercase() in listOf("july", "august") -> "Hiver5"
-            year == "2024" && month.lowercase() in listOf("january", "february") -> "Hiver6"
-            year == "2024" && month.lowercase() in listOf("july", "august", "september") -> "Hiver7"
-            else -> "Unknown"
-        }
-    }
-
     suspend fun fetchStudent(login: String): List<Student> {
         val response = client.get("https://api.intra.42.fr/v2/users?"){
             headers {
@@ -125,7 +109,7 @@ class StudentAPI(private val token42: String) {
         }
 
         return response.body<List<Student>>().map { student ->
-            val cohort = getCohortFromYearMonth(student.poolYear, student.poolMonth)
+            val cohort = CohortUtils.getCohortFromYearMonth(student.poolYear, student.poolMonth)
             student.copy(
                 cohort = cohort,
                 profileUrl = student.profileUrl + student.login,

--- a/src/main/kotlin/com/pace42/student/utils/Utils.kt
+++ b/src/main/kotlin/com/pace42/student/utils/Utils.kt
@@ -1,5 +1,9 @@
 package com.pace42.student.utils
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
 object CohortUtils {
     data class CohortDates(
         val year: String,
@@ -22,5 +26,18 @@ object CohortUtils {
             year == "2024" && month.lowercase() in listOf("july", "august", "september") -> "Hiver7"
             else -> "Unknown"
         }
+    }
+}
+
+object TimeUtils {
+    fun daysBetween(startDate: String, validatedDate: String?): Long? {
+
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd") // Expected date format
+        if(validatedDate == null)
+            return null
+        val validatedLocalDate = LocalDate.parse(validatedDate, formatter)
+        val startLocalDate = LocalDate.parse(startDate, formatter)
+
+        return ChronoUnit.DAYS.between(startLocalDate, validatedLocalDate)
     }
 }

--- a/src/main/kotlin/com/pace42/student/utils/Utils.kt
+++ b/src/main/kotlin/com/pace42/student/utils/Utils.kt
@@ -1,0 +1,26 @@
+package com.pace42.student.utils
+
+object CohortUtils {
+    data class CohortDates(
+        val year: String,
+        val month: String,
+    )
+
+    fun getYearMonthFromCohort(cohort: String): CohortDates {
+        return when (cohort) {
+            "Hiver5" -> CohortDates("2023", "july,august")
+            "Hiver6" -> CohortDates("2024", "january,february")
+            "Hiver7" -> CohortDates("2024", "july,august,september")
+            else -> CohortDates("Unknown", "Unknown")
+        }
+    }
+
+    fun getCohortFromYearMonth(year: String, month: String): String {
+        return when {
+            year == "2023" && month.lowercase() in listOf("july", "august") -> "Hiver5"
+            year == "2024" && month.lowercase() in listOf("january", "february") -> "Hiver6"
+            year == "2024" && month.lowercase() in listOf("july", "august", "september") -> "Hiver7"
+            else -> "Unknown"
+        }
+    }
+}

--- a/src/main/kotlin/com/pace42/student/utils/Utils.kt
+++ b/src/main/kotlin/com/pace42/student/utils/Utils.kt
@@ -40,4 +40,8 @@ object TimeUtils {
 
         return ChronoUnit.DAYS.between(startLocalDate, validatedLocalDate)
     }
+
+    fun getToday(): String{
+        return LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    }
 }

--- a/src/main/kotlin/com/pace42/student/utils/Utils.kt
+++ b/src/main/kotlin/com/pace42/student/utils/Utils.kt
@@ -19,11 +19,11 @@ object CohortUtils {
         }
     }
 
-    fun getCohortFromYearMonth(year: String, month: String): String {
+    fun getCohortFromYearMonth(year: String?, month: String?): String {
         return when {
-            year == "2023" && month.lowercase() in listOf("july", "august") -> "Hiver5"
-            year == "2024" && month.lowercase() in listOf("january", "february") -> "Hiver6"
-            year == "2024" && month.lowercase() in listOf("july", "august", "september") -> "Hiver7"
+            year == "2023" && month?.lowercase() in listOf("july", "august") -> "Hiver5"
+            year == "2024" && month?.lowercase() in listOf("january", "february") -> "Hiver6"
+            year == "2024" && month?.lowercase() in listOf("july", "august", "september") -> "Hiver7"
             else -> "Unknown"
         }
     }


### PR DESCRIPTION
Add the module that fetches Quest endpoints

### Major
* Add functions to fetch the `quest_user` endpoint. The simplest one is `fetchUserQuests` but it can also call to entire campus quest or cohort focus quests
* All the logic relies on obtaining a minimum `Quest` object with Rank information about when the Rank was validated. After that, these dates are used to calculate how much from the expected date the user completed the ranks (using `calculateQuestProgress`). This creates a much cleaner `QuestProgress` object. For example `fetchUserQuestProgress` will return the progress after calling  `fetchUserQuests`  endpoint.
* `fetchCohortsQuestProgress` is safe to use, as it first gets all the students per cohort and later calls the progress for each one, but is very very slow.
* To call massively the progress data, `fetchCampusQuests` can be used to get all the quests from all users first and then parse the resulting object. As the data is full of nulls and other problems like staff members being there, the invalid users are removed to allow the process to finish.

### Minot
* Added `Utils` module with Cohort and Time related generic functions
