### PR TITLE
:hammer: refactor: wrap up

### DIFF
--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -21,7 +21,9 @@ suspend fun main() {
 
     try {
         val students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
+        println("Fetched ${students.size} active students")
         val quests = questAPI.fetchCampusQuests()
+        println("Fetched ${quests.size} quests")
         val progress = questAPI.calculateCampusQuestProgress(quests)
 
         StudentProgressCSVExporter.exportStudentsProgress(
@@ -29,6 +31,7 @@ suspend fun main() {
             questProgress = progress,
             outputPath = Path("student_progress.csv")
         )
+        println("CSV exported successfully")
     } catch (e: Exception) {
         println(e)
         e.printStackTrace()

--- a/src/main/kotlin/com/pace42/student/Application.kt
+++ b/src/main/kotlin/com/pace42/student/Application.kt
@@ -1,7 +1,7 @@
 package com.pace42.student
 
 import com.pace42.student.auth.fetch42token
-import com.pace42.student.export.StudentCSVExporter
+import com.pace42.student.export.*
 import com.pace42.student.quest.QuestAPI
 import com.pace42.student.quest.QuestProgress
 import com.pace42.student.student.Student
@@ -16,31 +16,25 @@ suspend fun main() {
         return
     }
 
+    val questAPI = QuestAPI(token42)
+    val studentAPI = StudentAPI(token42)
+
     try {
-//        val  students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
-//        studentAPI.close()
-//        println("Number of students: ${students.size}")
+        val students = studentAPI.fetchCohorts("Hiver5", "Hiver6", "Hiver7")
+        val quests = questAPI.fetchCampusQuests()
+        val progress = questAPI.calculateCampusQuestProgress(quests)
 
-//        // Export to CSV
-//        val outputPath = Path("students_export.csv")
-//        StudentCSVExporter.exportBasicStudentInfo(students, outputPath)
-//        println("CSV exported successfully to: ${outputPath.absolutePathString()}")
-//        val quests = questAPI.fetchQuestProgress("upolat")
-//        quests.forEach { quest ->
-//            println(quest)
-//        }
-
-
-        val questAPI = QuestAPI(token42)
-        try {
-            val quests = questAPI.fetchCampusQuests()
-            println("Fetched quests for ${quests.size} quest entries")
-        } finally {
-            questAPI.close()
-        }
-
+        StudentProgressCSVExporter.exportStudentsProgress(
+            students = students,
+            questProgress = progress,
+            outputPath = Path("student_progress.csv")
+        )
     } catch (e: Exception) {
-        return
+        println(e)
+        e.printStackTrace()
+    } finally {
+        studentAPI.close()
+        questAPI.close()
     }
 }
 

--- a/src/main/kotlin/com/pace42/student/export/Export.kt
+++ b/src/main/kotlin/com/pace42/student/export/Export.kt
@@ -6,6 +6,7 @@ import org.apache.commons.csv.CSVPrinter
 import java.io.FileWriter
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
+import com.pace42.student.quest.QuestProgress
 
 class StudentCSVExporter {
     companion object {
@@ -38,7 +39,7 @@ class StudentCSVExporter {
             }
         }
 
-        private fun exportToCSV(
+         private fun exportToCSV(
             students: List<Student>,
             outputPath: Path,
             headers: Array<String>,
@@ -53,6 +54,83 @@ class StudentCSVExporter {
                     .use { csvPrinter ->
                         students.forEach { student ->
                             csvPrinter.printRecord(*recordMapper(student))
+                        }
+                    }
+            }
+        }
+    }
+}
+
+class StudentProgressCSVExporter {
+    companion object {
+        private val BASE_HEADERS = arrayOf(
+            "Cohort",
+            "Login",
+            "First Name",
+            "Last Name",
+            "Email",
+            "Pool Month",
+            "Pool Year",
+            "Profile URL",
+            "Graph URL"
+        )
+
+        private val RANK_NAMES = arrayOf(
+            "Common Core Rank 00",
+            "Common Core Rank 01",
+            "Common Core Rank 02",
+            "Common Core Rank 03",
+            "Common Core Rank 04",
+            "Common Core Rank 05",
+            "Common Core Rank 06"
+        )
+
+        fun exportStudentsProgress(
+            students: List<Student>,
+            questProgress: List<QuestProgress>,
+            outputPath: Path
+        ) {
+            // Create a map of login to quest progress records
+            val progressByLogin = questProgress.groupBy { it.login }
+
+            // Combine BASE_HEADERS with RANK_NAMES for complete header list
+            val allHeaders = BASE_HEADERS + RANK_NAMES
+
+            FileWriter(outputPath.absolutePathString()).use { writer ->
+                CSVFormat.DEFAULT
+                    .builder()
+                    .setHeader(*allHeaders)
+                    .build()
+                    .print(writer)
+                    .use { csvPrinter ->
+                        students.forEach { student ->
+                            // Get progress records for this student
+                            val studentProgress = progressByLogin[student.login] ?: emptyList()
+
+                            // Create a map of rank name to days buffer for easier lookup
+                            val rankBuffers = studentProgress.associate {
+                                it.rankName to (it.daysBuffer?.toString() ?: "")
+                            }
+
+                            // Build the complete record with base info and rank buffers
+                            val record = mutableListOf(
+                                student.cohort,
+                                student.login,
+                                student.firstName,
+                                student.lastName,
+                                student.email,
+                                student.poolMonth,
+                                student.poolYear,
+                                student.profileUrl,
+                                student.graphUrl
+                            )
+
+                            // Add the rank buffer values in order
+                            RANK_NAMES.forEach { rankName ->
+                                record.add(rankBuffers[rankName] ?: "")
+                            }
+
+                            csvPrinter.printRecord(record)
                         }
                     }
             }

--- a/src/main/kotlin/com/pace42/student/export/Export.kt
+++ b/src/main/kotlin/com/pace42/student/export/Export.kt
@@ -68,6 +68,7 @@ class StudentProgressCSVExporter {
             "Login",
             "First Name",
             "Last Name",
+            "Active Rank Buffer",
             "Email",
             "Pool Month",
             "Pool Year",
@@ -84,6 +85,13 @@ class StudentProgressCSVExporter {
             "Common Core Rank 05",
             "Common Core Rank 06"
         )
+
+        private fun findLastCompletedRankBuffer(rankBuffers: Map<String, String>): String {
+            val lastRankName = RANK_NAMES.findLast { rankName ->
+                rankBuffers[rankName]?.isNotEmpty() == true
+            }
+            return lastRankName?.let { rankBuffers[it] } ?: "Not Started"
+        }
 
         fun exportStudentsProgress(
             students: List<Student>,
@@ -112,6 +120,9 @@ class StudentProgressCSVExporter {
                                 it.rankName to (it.daysBuffer?.toString() ?: "")
                             }
 
+                            // Find the last completed rank
+                            val activeRankBuffer = findLastCompletedRankBuffer(rankBuffers)
+
                             // Build the complete record with base info and rank buffers
                             val record = mutableListOf(
                                 student.cohort,
@@ -119,6 +130,7 @@ class StudentProgressCSVExporter {
                                 student.firstName,
                                 student.lastName,
                                 student.email,
+                                activeRankBuffer,
                                 student.poolMonth,
                                 student.poolYear,
                                 student.profileUrl,

--- a/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
+++ b/src/main/kotlin/com/pace42/student/quest/QuestAPI.kt
@@ -76,6 +76,16 @@ class QuestAPI(private val token42: String) {
         }
     }
 
+    fun calculateCampusQuestProgress(quests: List<Quest>): List<QuestProgress> {
+        // Group quests by user login
+        val questsByUser = quests.groupBy { it.user.login }
+
+        // Calculate progress for each user's quests
+        return questsByUser.flatMap { (_, userQuests) ->
+            calculateQuestProgress(userQuests)
+        }
+    }
+
     suspend fun fetchCampusQuests(): List<Quest> {
         var currentPage = 1
         val pageSize = 100
@@ -145,6 +155,7 @@ class QuestAPI(private val token42: String) {
         }
     }
 
+    // calculate progress for a given user based on Quests
     fun calculateQuestProgress(quests: List<Quest>): List<QuestProgress> {
         if (quests.isEmpty()) return emptyList()
 
@@ -231,7 +242,7 @@ class QuestAPI(private val token42: String) {
                     try {
                         delay(500)
                         println("fetching ${student.login} quests...")
-                        fetchQuestProgress(student.login)
+                        fetchUserQuestProgress(student.login)
                     } catch (e: Exception) {
                         println("Error fetching progress for ${student.login}: ${e.message}")
                         emptyList()

--- a/src/main/kotlin/com/pace42/student/student/Student.kt
+++ b/src/main/kotlin/com/pace42/student/student/Student.kt
@@ -15,5 +15,6 @@ data class Student(
     @SerialName("pool_year") val poolYear: String,
     val profileUrl: String = "https://profile.intra.42.fr/users/",
     val graphUrl: String = "https://projects.intra.42.fr/projects/graph?login=",
-    val cohort: String = "Unknown"
+    val cohort: String = "Unknown",
+    @SerialName("active?")val active: Boolean = true,
 )

--- a/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
+++ b/src/main/kotlin/com/pace42/student/student/StudentAPI.kt
@@ -66,7 +66,7 @@ class StudentAPI(private val token42: String) {
                 when (response.status.value) {
                     429 -> {
                         println("Rate limit hit, waiting before retry...")
-                        delay(10000) // Wait 10 seconds before retrying
+                        delay(5000) // Wait 10 seconds before retrying
                         continue
                     }
                     200 -> {
@@ -86,13 +86,15 @@ class StudentAPI(private val token42: String) {
             }
 
             // add cohort tag to every student and correct urls
-            return allStudents.map { student ->
-                student.copy(
-                    cohort = cohort,
-                    profileUrl = student.profileUrl + student.login,
-                    graphUrl = student.graphUrl + student.login
-                )
-            }
+            return allStudents
+                .filter { it.active }  // Only keep active students
+                .map { student ->
+                    student.copy(
+                        cohort = cohort,
+                        profileUrl = student.profileUrl + student.login,
+                        graphUrl = student.graphUrl + student.login
+                    )
+                }
 
         } catch (e: Exception) {
             println(e)


### PR DESCRIPTION
Add final corrections for correct calculation and export.

### Major
* The MVP is now working, with a final CSV with the basic Student data merged with Progress data. For each student, we have now the `activeRank` column that represents the last completed or in progress rank with how many buffer days are pending. The the right of the table we can see the buffer days pending for each of the completed ranks until now + the active one.

### Minor
* Add `calculateCampusQuestProgress` to calculate progress per login
* Add the export function to merge both Student and Progress data classes into one
* As an additional filter, we remove the non-active Students when using `fetchCohort`.